### PR TITLE
Veritas9872 patch 1

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -124,7 +124,6 @@ RUN $conda install -y \
 # Use Intel OpenMP with optimizations enabled.
 # Some compilers can use OpenMP for faster builds.
 ENV KMP_BLOCKTIME=0
-ENV KMP_AFFINITY="granularity=fine,compact,1,0"
 ENV LD_PRELOAD=/opt/conda/lib/libiomp5.so:${LD_PRELOAD}
 
 ########################################################################
@@ -436,7 +435,6 @@ RUN echo /opt/conda/lib >> /etc/ld.so.conf.d/conda.conf && ldconfig
 # Use Intel OpenMP with optimizations. See documentation for details.
 # https://intel.github.io/intel-extension-for-pytorch/tutorials/performance_tuning/tuning_guide.html
 ENV KMP_BLOCKTIME=0
-ENV KMP_AFFINITY="granularity=fine,compact,1,0"
 ENV LD_PRELOAD=/opt/conda/lib/libiomp5.so:$LD_PRELOAD
 
 # Use Jemalloc for efficient memory management.

--- a/ngc.Dockerfile
+++ b/ngc.Dockerfile
@@ -75,12 +75,8 @@ RUN printf "[global]\nindex-url=${INDEX_URL}\ntrusted-host=${TRUSTED_HOST}\n" \
         -r /tmp/pip-ngc.requirements.txt && \
     rm /tmp/pip-ngc.requirements.txt
 
-ENV OMP_PROC_BIND=CLOSE
-ENV OMP_SCHEDULE=STATIC
-ENV KMP_WARNINGS=0
 ENV KMP_BLOCKTIME=0
 ENV LD_PRELOAD=/opt/conda/lib/libiomp5.so:$LD_PRELOAD
-ENV KMP_AFFINITY="granularity=fine,nonverbose,compact,1,0"
 ENV LD_PRELOAD=/usr/lib/x86_64-linux-gnu/libjemalloc.so.2:$LD_PRELOAD
 ENV MALLOC_CONF=background_thread:true,metadata_thp:auto,dirty_decay_ms:30000,muzzy_decay_ms:30000
 


### PR DESCRIPTION
Fix OMP/KMP variable configuration issues that force the system to use only one core when multiple processes, including from different terminals, are used. This was previously removed, but I reinstated the issue because of false confidence. Also, the NGC file had not been updated to reflect the bugfix yet.