### PR TITLE
Updates for Kubernetes and other compute cluster users.

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -45,10 +45,10 @@ repos:
 
   - repo: https://github.com/google/pyink
     rev: 23.3.0
-    hooks:  # Using PyInk, the Google fork of Black, for Python code formatting.
+    hooks: # Using PyInk, the Google fork of Black, for Python code formatting.
       - id: pyink
 
   - repo: https://github.com/psf/black
-    rev: 23.3.0  # Always use the same version as PyInk.
-    hooks:  # Using black for Jupyter Notebook formatting.
+    rev: 23.3.0 # Always use the same version as PyInk.
+    hooks: # Using black for Jupyter Notebook formatting.
       - id: black-jupyter

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -43,9 +43,12 @@ repos:
       - id: prettier
         files: \.(json|jsx|md|mdx|yaml)$
 
-  # Perhaps replace with `PyInk` if a pre-commit hook becomes available.
+  - repo: https://github.com/google/pyink
+    rev: 23.3.0
+    hooks:  # Using PyInk, Google's fork of Black, for Python code formatting.
+      - id: pyink
+
   - repo: https://github.com/psf/black
-    rev: 23.1.0
-    hooks:
-      - id: black
+    rev: 23.3.0
+    hooks:  # Using black for Jupyter Notebook formatting.
       - id: black-jupyter

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -45,10 +45,10 @@ repos:
 
   - repo: https://github.com/google/pyink
     rev: 23.3.0
-    hooks:  # Using PyInk, Google's fork of Black, for Python code formatting.
+    hooks:  # Using PyInk, the Google fork of Black, for Python code formatting.
       - id: pyink
 
   - repo: https://github.com/psf/black
-    rev: 23.3.0
+    rev: 23.3.0  # Always use the same version as PyInk.
     hooks:  # Using black for Jupyter Notebook formatting.
       - id: black-jupyter

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -32,13 +32,13 @@ repos:
 
   # Ruff should be executed before other formatters.
   - repo: https://github.com/charliermarsh/ruff-pre-commit
-    rev: "v0.0.256"
+    rev: "v0.0.260"
     hooks:
       - id: ruff
         args: [--exit-non-zero-on-fix]
 
   - repo: https://github.com/pre-commit/mirrors-prettier
-    rev: v3.0.0-alpha.6 # Update to stable ASAP.
+    rev: v3.0.0-alpha.6
     hooks:
       - id: prettier
         files: \.(json|jsx|md|mdx|yaml)$

--- a/Dockerfile
+++ b/Dockerfile
@@ -463,6 +463,8 @@ RUN groupadd -f -g ${GID} ${GRP} && \
 COPY --link --from=train-builds --chown=${UID}:${GID} /opt/conda /opt/conda
 RUN echo /opt/conda/lib >> /etc/ld.so.conf.d/conda.conf && ldconfig
 
+# Intel OpenMP thread blocking time in ms.
+ENV KMP_BLOCKTIME=0
 # Enable Intel MKL optimizations on AMD CPUs.
 # https://danieldk.eu/Posts/2020-08-31-MKL-Zen.html
 ENV MKL_DEBUG_CPU_TYPE=5
@@ -472,6 +474,8 @@ ENV LD_PRELOAD=/opt/conda/libfakeintel.so:${LD_PRELOAD}
 ENV LD_PRELOAD=/opt/conda/lib/libiomp5.so:$LD_PRELOAD
 # Use Jemalloc for efficient memory management.
 ENV LD_PRELOAD=/opt/conda/lib/libjemalloc.so:$LD_PRELOAD
+# Jemalloc memory allocation configuration.
+ENV MALLOC_CONF="background_thread:true,metadata_thp:auto,dirty_decay_ms:30000,muzzy_decay_ms:30000"
 
 USER ${USR}
 # Docker must use absolute paths in `COPY` and cannot find `${HOME}`.

--- a/Dockerfile
+++ b/Dockerfile
@@ -453,9 +453,11 @@ FROM train-root AS train-user-exclude
 # This stage exists to create images for use in Kubernetes clusters or for
 # uploading image to a container registry, where interactive configurations
 # are unnecessary and having the user set to `root` is most convenient.
+# Singularity users may also find this stage convenient.
 # It is designed to be as close to the interactive development environment as
 # possible, with the same `apt`, `conda`, and `pip` packages installed.
-# Most users may ignore this stage except when publishing the training image.
+# Most users may safely ignore this stage except when publishing an image
+# to a container repository for reproducibility.
 
 COPY --link --from=train-builds /opt/conda /opt/conda
 RUN echo /opt/conda/lib >> /etc/ld.so.conf.d/conda.conf && ldconfig
@@ -465,7 +467,7 @@ FROM train-root AS train-user-include
 # This stage exists to create an interactive development environment with ease
 # of experimentation and debugging in mind. A new `sudo` user is created to help
 # prevent file ownership issues and accidents while not limiting freedom.
-# All user-related and interactive options should be placed here.
+# All user-related and interactive configurations should be placed here.
 # This is the default training stage that most users will use most of the time.
 
 ARG GID

--- a/Dockerfile
+++ b/Dockerfile
@@ -31,8 +31,8 @@
 # Users must specify the full version, e.g., `11.2.2`.
 
 ARG MKL_MODE
-ARG USER_MODE
 ARG BUILD_MODE
+ARG INTERACTIVE_MODE
 ARG USE_CUDA=1
 ARG CUDA_VERSION
 ARG CUDNN_VERSION
@@ -521,7 +521,7 @@ RUN {   echo "alias ll='ls -lh'"; \
     } >> ${HOME}/.zshrc
 
 ########################################################################
-FROM train-user-${USER_MODE} AS train
+FROM train-user-${INTERACTIVE_MODE} AS train
 # Common configurations performed after `/opt/conda` installation
 # should be placed here. Do not include any user-related options.
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -449,7 +449,7 @@ RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
     rm -rf /var/lib/apt/lists/*
 
 ########################################################################
-FROM train-root AS train-user-exclude
+FROM train-root AS train-interactive-exclude
 # This stage exists to create images for use in Kubernetes clusters or for
 # uploading image to a container registry, where interactive configurations
 # are unnecessary and having the user set to `root` is most convenient.
@@ -463,7 +463,7 @@ COPY --link --from=train-builds /opt/conda /opt/conda
 RUN echo /opt/conda/lib >> /etc/ld.so.conf.d/conda.conf && ldconfig
 
 ########################################################################
-FROM train-root AS train-user-include
+FROM train-root AS train-interactive-include
 # This stage exists to create an interactive development environment with ease
 # of experimentation and debugging in mind. A new `sudo` user is created to help
 # prevent file ownership issues and accidents while not limiting freedom.
@@ -521,7 +521,7 @@ RUN {   echo "alias ll='ls -lh'"; \
     } >> ${HOME}/.zshrc
 
 ########################################################################
-FROM train-user-${INTERACTIVE_MODE} AS train
+FROM train-interactive-${INTERACTIVE_MODE} AS train
 # Common configurations performed after `/opt/conda` installation
 # should be placed here. Do not include any user-related options.
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -31,6 +31,7 @@
 # Users must specify the full version, e.g., `11.2.2`.
 
 ARG MKL_MODE
+ARG USER_MODE
 ARG BUILD_MODE
 ARG USE_CUDA=1
 ARG CUDA_VERSION
@@ -411,9 +412,10 @@ RUN echo 'int mkl_serv_intel_cpu_true() {return 1;}' > /opt/conda/fakeintel.c &&
     gcc -shared -fPIC -o /opt/conda/libfakeintel.so /opt/conda/fakeintel.c
 
 ########################################################################
-FROM ${TRAIN_IMAGE} AS train
-# Example training image for Ubuntu 20.04+ on Intel x86_64 CPUs.
+FROM ${TRAIN_IMAGE} AS train-base
+# Example Ubuntu training image on Intel x86_64 CPUs.
 # Edit this section if necessary but use `docker-compose.yaml` if possible.
+# Common configurations performed before creating a user should be placed here.
 
 LABEL maintainer=veritas9872@gmail.com
 ENV LANG=C.UTF-8
@@ -446,6 +448,26 @@ RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
     xargs apt-get install -y --no-install-recommends && \
     rm -rf /var/lib/apt/lists/*
 
+########################################################################
+FROM train-root AS train-user-exclude
+# This stage exists to create images for use in Kubernetes clusters or for
+# uploading image to a container registry, where interactive configurations
+# are unnecessary and having the user set to `root` is most convenient.
+# It is designed to be as close to the interactive development environment as
+# possible, with the same `apt`, `conda`, and `pip` packages installed.
+# Most users may ignore this stage except when publishing the training image.
+
+COPY --link --from=train-builds /opt/conda /opt/conda
+RUN echo /opt/conda/lib >> /etc/ld.so.conf.d/conda.conf && ldconfig
+
+########################################################################
+FROM train-root AS train-user-include
+# This stage exists to create an interactive development environment with ease
+# of experimentation and debugging in mind. A new `sudo` user is created to help
+# prevent file ownership issues and accidents while not limiting freedom.
+# All user-related and interactive options should be placed here.
+# This is the default training stage that most users will use most of the time.
+
 ARG GID
 ARG UID
 ARG GRP=user
@@ -463,34 +485,10 @@ RUN groupadd -f -g ${GID} ${GRP} && \
 COPY --link --from=train-builds --chown=${UID}:${GID} /opt/conda /opt/conda
 RUN echo /opt/conda/lib >> /etc/ld.so.conf.d/conda.conf && ldconfig
 
-# Intel OpenMP thread blocking time in ms.
-ENV KMP_BLOCKTIME=0
-# Use Intel OpenMP with optimizations. See documentation for details.
-# https://intel.github.io/intel-extension-for-pytorch/tutorials/performance_tuning/tuning_guide.html
-ENV LD_PRELOAD=/opt/conda/lib/libiomp5.so:$LD_PRELOAD
-
-# Enable Intel MKL optimizations on AMD CPUs.
-# https://danieldk.eu/Posts/2020-08-31-MKL-Zen.html
-ENV MKL_DEBUG_CPU_TYPE=5
-ENV LD_PRELOAD=/opt/conda/libfakeintel.so:${LD_PRELOAD}
-
-# Use Jemalloc for efficient memory management.
-ENV LD_PRELOAD=/opt/conda/lib/libjemalloc.so:$LD_PRELOAD
-# Jemalloc memory allocation configuration.
-ENV MALLOC_CONF="background_thread:true,metadata_thp:auto,dirty_decay_ms:30000,muzzy_decay_ms:30000"
-
 USER ${USR}
 # Docker must use absolute paths in `COPY` and cannot find `${HOME}`.
 # Setting ${HOME} to its default value explicitly as a fix.
 ARG HOME=/home/${USR}
-
-# `PROJECT_ROOT` is where the project code will reside.
-# The conda root path must be placed at the end of the
-# PATH variable to prevent system program search errors.
-# This is the opposite of the build stage.
-ARG PROJECT_ROOT=/opt/project
-ENV PATH=${PROJECT_ROOT}:/opt/conda/bin:${PATH}
-ENV PYTHONPATH=${PROJECT_ROOT}
 
 # Setting the prompt to `pure`, which is available on all terminals without additional settings.
 # This is a personal preference and users may use any prompt that they wish (e.g., oh-my-zsh).
@@ -519,6 +517,35 @@ RUN echo "source ${ZSHS_PATH}/zsh-syntax-highlighting.zsh" >> ${HOME}/.zshrc
 RUN {   echo "alias ll='ls -lh'"; \
         echo "alias wns='watch nvidia-smi'"; \
     } >> ${HOME}/.zshrc
+
+########################################################################
+FROM train-user-${USER_MODE} AS train
+# Common configurations performed after `/opt/conda` installation
+# should be placed here. Do not include any user-related options.
+
+# Intel OpenMP thread blocking time in ms.
+ENV KMP_BLOCKTIME=0
+# Use Intel OpenMP with optimizations. See documentation for details.
+# https://intel.github.io/intel-extension-for-pytorch/tutorials/performance_tuning/tuning_guide.html
+ENV LD_PRELOAD=/opt/conda/lib/libiomp5.so:$LD_PRELOAD
+
+# Enable Intel MKL optimizations on AMD CPUs.
+# https://danieldk.eu/Posts/2020-08-31-MKL-Zen.html
+ENV MKL_DEBUG_CPU_TYPE=5
+ENV LD_PRELOAD=/opt/conda/libfakeintel.so:${LD_PRELOAD}
+
+# Use Jemalloc for efficient memory management.
+ENV LD_PRELOAD=/opt/conda/lib/libjemalloc.so:$LD_PRELOAD
+# Jemalloc memory allocation configuration.
+ENV MALLOC_CONF="background_thread:true,metadata_thp:auto,dirty_decay_ms:30000,muzzy_decay_ms:30000"
+
+# `PROJECT_ROOT` is where the project code will reside.
+# The conda root path must be placed at the end of the
+# PATH variable to prevent system program search errors.
+# This is the opposite of the build stage.
+ARG PROJECT_ROOT=/opt/project
+ENV PATH=${PROJECT_ROOT}:/opt/conda/bin:${PATH}
+ENV PYTHONPATH=${PROJECT_ROOT}
 
 # `PROJECT_ROOT` belongs to `USR` if created after `USER` has been set.
 # Not so for pre-existing directories, which will still belong to root.

--- a/Dockerfile
+++ b/Dockerfile
@@ -449,7 +449,7 @@ RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
     rm -rf /var/lib/apt/lists/*
 
 ########################################################################
-FROM train-root AS train-interactive-exclude
+FROM train-base AS train-interactive-exclude
 # This stage exists to create images for use in Kubernetes clusters or for
 # uploading image to a container registry, where interactive configurations
 # are unnecessary and having the user set to `root` is most convenient.
@@ -463,7 +463,7 @@ COPY --link --from=train-builds /opt/conda /opt/conda
 RUN echo /opt/conda/lib >> /etc/ld.so.conf.d/conda.conf && ldconfig
 
 ########################################################################
-FROM train-root AS train-interactive-include
+FROM train-base AS train-interactive-include
 # This stage exists to create an interactive development environment with ease
 # of experimentation and debugging in mind. A new `sudo` user is created to help
 # prevent file ownership issues and accidents while not limiting freedom.

--- a/Dockerfile
+++ b/Dockerfile
@@ -525,10 +525,12 @@ FROM train-interactive-${INTERACTIVE_MODE} AS train
 # Common configurations performed after `/opt/conda` installation
 # should be placed here. Do not include any user-related options.
 
+# Use Intel OpenMP with optimizations. See the documentation for details.
+# https://intel.github.io/intel-extension-for-pytorch/cpu/latest/tutorials/performance_tuning/tuning_guide.html
 # Intel OpenMP thread blocking time in ms.
 ENV KMP_BLOCKTIME=0
-# Use Intel OpenMP with optimizations. See documentation for details.
-# https://intel.github.io/intel-extension-for-pytorch/tutorials/performance_tuning/tuning_guide.html
+# Configure CPU thread affinity.
+ENV KMP_AFFINITY="granularity=fine,compact,1,0"
 ENV LD_PRELOAD=/opt/conda/lib/libiomp5.so:$LD_PRELOAD
 
 # Enable Intel MKL optimizations on AMD CPUs.

--- a/Dockerfile
+++ b/Dockerfile
@@ -465,13 +465,15 @@ RUN echo /opt/conda/lib >> /etc/ld.so.conf.d/conda.conf && ldconfig
 
 # Intel OpenMP thread blocking time in ms.
 ENV KMP_BLOCKTIME=0
+# Use Intel OpenMP with optimizations. See documentation for details.
+# https://intel.github.io/intel-extension-for-pytorch/tutorials/performance_tuning/tuning_guide.html
+ENV LD_PRELOAD=/opt/conda/lib/libiomp5.so:$LD_PRELOAD
+
 # Enable Intel MKL optimizations on AMD CPUs.
 # https://danieldk.eu/Posts/2020-08-31-MKL-Zen.html
 ENV MKL_DEBUG_CPU_TYPE=5
 ENV LD_PRELOAD=/opt/conda/libfakeintel.so:${LD_PRELOAD}
-# Use Intel OpenMP with optimizations. See documentation for details.
-# https://intel.github.io/intel-extension-for-pytorch/tutorials/performance_tuning/tuning_guide.html
-ENV LD_PRELOAD=/opt/conda/lib/libiomp5.so:$LD_PRELOAD
+
 # Use Jemalloc for efficient memory management.
 ENV LD_PRELOAD=/opt/conda/lib/libjemalloc.so:$LD_PRELOAD
 # Jemalloc memory allocation configuration.

--- a/README.md
+++ b/README.md
@@ -127,13 +127,13 @@ CCA=8.6                          # Compute capability. CCA=8.6 for RTX3090.
 # Used only if building PyTorch from source (`BUILD_MODE=include`).
 # The `*_TAG` variables are used only if `BUILD_MODE=include`. No effect otherwise.
 BUILD_MODE=exclude               # Whether to build PyTorch from source.
-PYTORCH_VERSION_TAG=v1.13.1      # Any `git` branch or tag name can be used.
-TORCHVISION_VERSION_TAG=v0.14.1
+PYTORCH_VERSION_TAG=v2.0.0       # Any `git` branch or tag name can be used.
+TORCHVISION_VERSION_TAG=v0.15.1
 
 # General environment configurations.
 LINUX_DISTRO=ubuntu              # Visit the NVIDIA Docker Hub repo for available base images.
 DISTRO_VERSION=22.04             # https://hub.docker.com/r/nvidia/cuda/tags
-CUDA_VERSION=11.7.1              # Must be compatible with hardware and CUDA driver.
+CUDA_VERSION=11.8.0              # Must be compatible with hardware and CUDA driver.
 CUDNN_VERSION=8                  # Only major version specifications are available.
 PYTHON_VERSION=3.10              # Specify the Python version.
 MKL_MODE=include                 # Enable MKL for Intel CPUs.
@@ -141,7 +141,7 @@ TZ=Asia/Seoul                    # Set the container timezone.
 
 # Advanced Usage.
 TARGET_STAGE=train               # Target Dockerfile stage. The `*.whl` files are available in `train-builds`.
-INTERACTIVE_MODE=include         # Whether to create an interactive image or one for publishing.
+INTERACTIVE_MODE=include         # Whether to create an interactive image or a static one for publishing.
 ```
 
 ## General Usage After Initial Installation and Configuration

--- a/README.md
+++ b/README.md
@@ -141,6 +141,7 @@ TZ=Asia/Seoul                    # Set the container timezone.
 
 # Advanced Usage.
 TARGET_STAGE=train               # Target Dockerfile stage. The `*.whl` files are available in `train-builds`.
+USER_MODE=include                # Whether to create an interactive image or one for publishing.
 ```
 
 ## General Usage After Initial Installation and Configuration

--- a/README.md
+++ b/README.md
@@ -215,6 +215,9 @@ Please read the Makefile to see the exact commands.
   For example, one can set a volume pair as `${HOME}/.vscode-project1:/home/${USR}/.vscode-server` for project1.
   Do not forget to create `${HOME}/.vscode-project1` on the host first. Otherwise, the directory will be owned by `root`,
   which will cause VSCode to stall indefinately.
+- If any networking issues arise, check `docker network ls` and check for conflicts.
+  Most networking and SSH problems can be solved by running `docker network prune`. 
+
 
 ## Project Overview
 

--- a/README.md
+++ b/README.md
@@ -141,7 +141,7 @@ TZ=Asia/Seoul                    # Set the container timezone.
 
 # Advanced Usage.
 TARGET_STAGE=train               # Target Dockerfile stage. The `*.whl` files are available in `train-builds`.
-USER_MODE=include                # Whether to create an interactive image or one for publishing.
+INTERACTIVE_MODE=include         # Whether to create an interactive image or one for publishing.
 ```
 
 ## General Usage After Initial Installation and Configuration

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -108,9 +108,6 @@ services:
       TZ: ${TZ:-Asia/Seoul} # Timezone settings used during runtime.
       HISTSIZE: 50000 # Hard-coded large command history size.
       CUDA_DEVICE_ORDER: PCI_BUS_ID
-      KMP_BLOCKTIME: 0 # Intel OpenMP thread blocking time in ms.
-      # Jemalloc memory allocation configuration.
-      MALLOC_CONF: "background_thread:true,metadata_thp:auto,dirty_decay_ms:30000,muzzy_decay_ms:30000"
     deploy: # API dependent on compose version.
       resources:
         reservations:

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -22,6 +22,11 @@
 # explanation of how to specify the `TORCH_CUDA_ARCH_LIST` variable.
 # The variable `CCA` is used to specify `TORCH_CUDA_ARCH_LIST`.
 
+networks: # Use the host network instead of creating a separate network.
+  default: # This reduces load and conflicts with the host network.
+    name: host # This may cause security issues in production, however.
+    external: true
+
 services:
   train: # Default service name. Change the name for each project.
     # Set to the service name. Makes terminals easier to tell apart.

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -59,6 +59,7 @@ services:
       context: . # Nearly all files are ignored due to `.dockerignore` settings.
       dockerfile: Dockerfile
       args: # Equivalent to `--build-arg`.
+        USER_MODE: ${USER_MODE:-include}
         BUILD_MODE: ${BUILD_MODE:-exclude}
         BUILD_TEST: 1 # Enable tests to have identical configurations with deployment.
         USE_NNPACK: 0

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -59,7 +59,7 @@ services:
       context: . # Nearly all files are ignored due to `.dockerignore` settings.
       dockerfile: Dockerfile
       args: # Equivalent to `--build-arg`.
-        USER_MODE: ${USER_MODE:-include}
+        INTERACTIVE_MODE: ${INTERACTIVE_MODE:-include}
         BUILD_MODE: ${BUILD_MODE:-exclude}
         BUILD_TEST: 1 # Enable tests to have identical configurations with deployment.
         USE_NNPACK: 0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,7 @@ target-version = ['py310']
 include = '\.pyi?$'
 
 [tool.pytest.ini_options]
-minversion = "7.0"  # Update to 7.2.3 ASAP.
+minversion = "7.0"  # Update to 7.2.3 as soon as it becomes available.
 addopts = """\
     --capture=tee-sys \
     --doctest-modules \
@@ -63,7 +63,7 @@ ignore = [
   "D417", # Missing argument descriptions
   "E501", # line length violations
 ]
-# Enable autofix behavior by-default when running `ruff`
+# Enable autofix behavior by-default when running `ruff`.
 fix = true
 # By default, always enumerate fixed violations.
 show-fixes = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,6 +5,12 @@ include = '\.pyi?$'
 # Black excludes files in `.gitignore` if no `exclude` is specified.
 # https://black.readthedocs.io/en/stable/usage_and_configuration/file_collection_and_discovery.html#gitignore
 
+[tool.pyink]
+# PyInk is the Google fork of Black.
+# https://github.com/google/pyink
+line-length = 100
+target-version = ['py310']
+include = '\.pyi?$'
 
 [tool.pytest.ini_options]
 minversion = "7.0"  # Update to 7.2.3 ASAP.

--- a/reqs/apt-train.requirements.txt
+++ b/reqs/apt-train.requirements.txt
@@ -1,6 +1,7 @@
 # Example `apt` requirements file.
 # `sudo` and `zsh` are required packages.
 at
+numactl
 sudo
 watchman  # For pyre-check only.
 zsh

--- a/reqs/train-environment.yaml
+++ b/reqs/train-environment.yaml
@@ -20,13 +20,13 @@ dependencies: # Use conda packages if possible.
   - libjpeg-turbo # TorchVision dependency.
   - libpng # TorchVision dependency.
   - numpy # Intel optimized NumPy is not available on PyPI.
-  - mkl # Essential if BUILD_MODE=include and MKL_MODE=include.
   - sympy # A PyTorch dependency.
   - tqdm
   - typing_extensions # A PyTorch dependency.
 
   # Essential packages.
   - jemalloc
+  - mkl  # Intel OpenMP (iomp) and other Intel optimizations depend on MKL.
   - openssh
   - tzdata
 

--- a/reqs/train-environment.yaml
+++ b/reqs/train-environment.yaml
@@ -26,7 +26,7 @@ dependencies: # Use conda packages if possible.
 
   # Essential packages.
   - jemalloc
-  - mkl  # Intel OpenMP (iomp) and other Intel optimizations depend on MKL.
+  - mkl # Intel OpenMP (iomp) and other Intel optimizations depend on MKL.
   - openssh
   - tzdata
 


### PR DESCRIPTION
This is a major update for greater convenience in Kubernetes clusters and for publishing the training images.
Until now, Cresset has mostly been focused on making a convenient environment for local or nearly local development on servers.
However, Docker Compose cannot be used in Kubernetes or other compute cluster environments.
Also, when publishing the training image to a container repository for reproducible research, having the user specified is inconvenient because the UID and GID values will likely differ.
This PR therefore separates the user-related configurations into a separate stage and adds an option `USER_MODE` to allow the user to choose between the two options.
The major downside of this change is that the readability of the `train` stage has gone down significantly because it is now more complex and visually cluttered.
Also, while not currently a problem, there may emerge issues where some configurations and options cannot be cleanly separated into different stages, which will require rewriting the stage.
While the above problems are non-trivial, the `train` stage will be split into related stages so that all installed packages will be the same, even if some configurations and options are different. For now, this has the higher priority as creating a totally separate stage for uploading the training stage image would almost certainly cause divergence as the image code is updated.