### PR TITLE
Improve `curl` flags.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -65,7 +65,8 @@ FROM ${CURL_IMAGE} AS curl-conda
 # https://www.anaconda.com/end-user-license-agreement-miniconda
 
 ARG CONDA_URL
-RUN mkdir /tmp/conda && curl -fsSL -v -o /tmp/conda/miniconda.sh -O ${CONDA_URL}
+WORKDIR /tmp/conda
+RUN curl -fvSL -o /tmp/conda/miniconda.sh ${CONDA_URL}
 
 ########################################################################
 FROM ${BUILD_IMAGE} AS install-conda

--- a/Makefile
+++ b/Makefile
@@ -134,7 +134,7 @@ COMPOSE_FILE = ${COMPOSE_PATH}/docker-compose
 
 ${COMPOSE_FILE}:
 	mkdir -p "${COMPOSE_PATH}"
-	curl -SL "${COMPOSE_URL}" -o "${COMPOSE_FILE}"
+	curl -fvSL "${COMPOSE_URL}" -o "${COMPOSE_FILE}"
 	chmod +x "${COMPOSE_FILE}"
 
 install-compose: ${COMPOSE_FILE}

--- a/dockerfiles/simple.Dockerfile
+++ b/dockerfiles/simple.Dockerfile
@@ -37,7 +37,7 @@ COPY --link ../reqs/apt-simple.requirements.txt /tmp/apt/requirements.txt
 
 ARG CONDA_URL
 WORKDIR /tmp/conda
-RUN curl -fsSL -v -o /tmp/conda/miniconda.sh -O ${CONDA_URL} && \
+RUN curl -fvSL -o /tmp/conda/miniconda.sh ${CONDA_URL} && \
     /bin/bash /tmp/conda/miniconda.sh -b -p /opt/conda && \
     printf "channels:\n  - conda-forge\n  - nodefaults\n" > /opt/conda/.condarc
 WORKDIR /


### PR DESCRIPTION
Unify all `curl` installations to have the same options and configurations.

The previous installation had redundant flags that contradicted each other, which looked amateurish.