### PR TITLE
Change Makefile behavior (again) and update docs to reflect this

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,10 +6,6 @@
 # https://docs.docker.com/engine/reference/commandline/compose
 
 # **Change `SERVICE` to specify other services and projects.**
-# `SERVICE`, `COMMAND`, and `PROJECT` take environment variables from
-# the user's shell if specified, making it easier to configure commands.
-# The `?=` means that default variables are only used if the variable is
-# unset in the user's environment, i.e., the shell.
 # Note that variables defined in the host shell are ignored if the
 # `.env` file also defines those variables due to the current logic.
 SERVICE = train
@@ -95,9 +91,7 @@ ${OVERRIDE_FILE}:
 over: ${OVERRIDE_FILE}
 
 # Optionally read variables from the environment file if it exists.
-# The `-include` will include variables defined in the `${ENV_FILE}`
-# but will not cause an error if it does not exist.
-# This line must be placed before all other variable definitions to allow
+# This line must be placed after all other variable definitions to allow
 # variables in the `${ENV_FILE}` to be overridden by user-defined values.
 ENV_FILE = .env
 -include ${ENV_FILE}

--- a/Makefile
+++ b/Makefile
@@ -5,14 +5,6 @@
 # See URL below for documentation on Docker Compose.
 # https://docs.docker.com/engine/reference/commandline/compose
 
-# Optionally read variables from the environment file if it exists.
-# The `-include` will include variables defined in the `${ENV_FILE}`
-# but will not cause an error if it does not exist.
-# This line must be placed before all other variable definitions to allow
-# variables in the `${ENV_FILE}` to be overridden by user-defined values.
-ENV_FILE = .env
--include ${ENV_FILE}
-
 # **Change `SERVICE` to specify other services and projects.**
 # `SERVICE`, `COMMAND`, and `PROJECT` take environment variables from
 # the user's shell if specified, making it easier to configure commands.
@@ -20,8 +12,8 @@ ENV_FILE = .env
 # unset in the user's environment, i.e., the shell.
 # Note that variables defined in the host shell are ignored if the
 # `.env` file also defines those variables due to the current logic.
-SERVICE ?= train
-COMMAND ?= /bin/zsh
+SERVICE = train
+COMMAND = /bin/zsh
 
 # `PROJECT` is equivalent to `COMPOSE_PROJECT_NAME`.
 # Project names are made unique for each user to prevent name clashes,
@@ -101,6 +93,14 @@ ${OVERRIDE_FILE}:
 	printf ${OVERRIDE_BASE} >> ${OVERRIDE_FILE}
 # Cannot use `override` as a recipe name as it is a `make` keyword.
 over: ${OVERRIDE_FILE}
+
+# Optionally read variables from the environment file if it exists.
+# The `-include` will include variables defined in the `${ENV_FILE}`
+# but will not cause an error if it does not exist.
+# This line must be placed before all other variable definitions to allow
+# variables in the `${ENV_FILE}` to be overridden by user-defined values.
+ENV_FILE = .env
+-include ${ENV_FILE}
 
 build: check vs # Rebuild the image before creating a new container.
 	COMPOSE_DOCKER_CLI_BUILD=1 DOCKER_BUILDKIT=1 \

--- a/README.md
+++ b/README.md
@@ -55,9 +55,12 @@ If this is your first time using this project, follow these steps:
    for the latest installation information. Note that Docker Compose V2
    is available for WSL users with Docker Desktop by default.
 
-4. Run `make env` on the terminal at project root to create a basic `.env` file.
+4. Run `make env SERVICE=${YOUR_DESIRED_SERVICE}` on the terminal 
+   at project root to create a basic `.env` file.
    The `.env` file provides environment variables for `docker-compose.yaml`,
    allowing different users and machines to set their own variables as required.
+   The Makefile has also been configured to read values from the `.env` file
+   if it exists, allowing non-default values to be specified only once.
    Each host should have a separate `.env` file for host-specific configurations.
 
 5. Run `make over` to create a `docker-compose.override.yaml` files.
@@ -66,8 +69,8 @@ If this is your first time using this project, follow these steps:
 
 ## Project Configuration
 
-1. To build PyTorch from source, set `BUILD_MODE=include` and set the
-   CUDA Compute Capability (CCA) of the target NVIDIA GPU.
+1. To build PyTorch from source, set `BUILD_MODE=include` and the
+   CUDA Compute Capability (CCA) of the target NVIDIA GPU in the `.env` file.
    Visit the NVIDIA [website](https://developer.nvidia.com/cuda-gpus#compute)
    to find compute capabilities of NVIDIA GPUs. Visit the
    [documentation](https://docs.nvidia.com/cuda/cuda-c-programming-guide/index.html#compute-capabilities)
@@ -97,7 +100,7 @@ If this is your first time using this project, follow these steps:
    Run `make over` to create a `docker-compose.override.yaml` file
    to add custom volumes and configurations.
    The `docker-compose.override.yaml` file is excluded from version control
-   to allow per-user/per-server settings.
+   to allow per-user and per-server settings.
 
 5. (Advanced) If an external file must be included in the Docker image build process,
    edit the `.dockerignore` file to allow the Docker context to find the external file.
@@ -106,8 +109,8 @@ If this is your first time using this project, follow these steps:
 
 Example `.env` file for user with username `USERNAME`,
 group name `GROUPNAME`, user id `1000`, group id `1000` on service `train`.
-Edit the `docker-compose.yaml` file and the
-`Makefile` to specify services other than `train`.
+Use the `simple` service if no dependencies need to be compiled and requirements
+can either be downloaded or installed via `apt`, `conda` and `pip`.
 
 ```text
 # Generated automatically by `make env`.
@@ -115,7 +118,7 @@ GID=1000
 UID=1000
 GRP=GROUPNAME
 USR=USERNAME
-HOSTNAME=train
+HOST_NAME=train
 IMAGE_NAME=cresset:train-USERNAME
 
 # [[Optional]]: Fill in these configurations manually if the defaults do not suffice.
@@ -431,7 +434,8 @@ To solve this problem, simply change the directory ownership to the
 user with `sudo chown -R $(id -u):$(id -g) ${HOME}/.vscode-server`.
 This command can be run either on the host or inside the container,
 which is useful if `sudo` permissions are unavailable on the host.
-For other problems concerning VSCode, try deleting `~/.vscode-server`.
+
+For other VSCode problems, try deleting `~/.vscode-server` on the host.
 
 # Known Issues
 
@@ -461,7 +465,7 @@ For other problems concerning VSCode, try deleting `~/.vscode-server`.
    [not fail-safe](https://stackoverflow.com/a/8573310/9289275).
 
 6. `torch.cuda.is_available()` will return a `... UserWarning:
-CUDA initialization:...` error or the image will simply not start if
+   CUDA initialization:...` error or the image will simply not start if
    the CUDA driver on the host is incompatible with the CUDA version on
    the Docker image. Either upgrade the host CUDA driver or downgrade
    the CUDA version of the image. Check the

--- a/reqs/simple-environment.yaml
+++ b/reqs/simple-environment.yaml
@@ -4,11 +4,12 @@ channels:
   - conda-forge # Always use conda-forge instead.
   - nvidia # CUDA-related packages are available in the NVIDIA channel.
 dependencies: # Use conda packages if possible.
-  - python==3.10
+  - intel::python==3.10
   - pytorch::pytorch # Only install PyTorch-related packages from the PyTorch channel.
   - pytorch::torchvision
   - pytorch::pytorch-cuda==11.8
-  - tqdm
-  - mkl
   - jemalloc
+  - intel::mkl
+  - intel::numpy  # Use Numpy built with the Intel compiler for best performance with MKL.
   - pytest
+  - tqdm


### PR DESCRIPTION
Close #111 
The Makefile now reads the `.env` as a default properly. The previous behavior where environment variables in the host shell were read by the Makefile, which was fortunately never documented in the `README.md`, was removed as it would cause too much confusion and the `.env` file could now perform the role of specifying the `SERVICE` and other Make variables.
This PR also updates the documentation on how to use the new features that have recently been implemented. It is still not enough but more will be coming.
Also, the `simple` service now uses Python and Numpy compiled with Intel(R) compilers for better compatibility with MKL. According to the Intel blog, Numpy built with GCC or other C compilers may be slower than Numpy built with Intel compilers. https://www.intel.com/content/www/us/en/developer/articles/technical/easy-intro-to-the-intel-distribution-for-python.html
The major downside is that versions of the Intel compiled libraries are always older than the latest version on the `conda-forge` channel. However, using the Intel version is just a default, and users can change this setting if they so desire.
