### PR TITLE
Miscellaneous bug fixes and updates.

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -59,7 +59,6 @@ repos:
     rev: 23.3.0 # Always use the same version as PyInk.
     hooks: # Using black for Jupyter Notebook formatting.
       - id: black-jupyter
-
 #  - repo: local # Clear Jupyter outputs before committing.
 #    hooks:
 #      - id: jupyter-nb-clear-output

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -19,7 +19,6 @@ repos:
       - id: check-toml
       - id: check-xml
       - id: check-yaml
-      - id: debug-statements
       - id: destroyed-symlinks
       - id: detect-private-key
       - id: end-of-file-fixer
@@ -45,22 +44,21 @@ repos:
     rev: v0.9.0
     hooks:
       - id: shellcheck
-  #      args: ["--severity=warning"]  # Optionally only show errors and warnings
 
   - repo: https://github.com/google/pyink
     rev: 23.3.1
     hooks: # Using PyInk, the Google fork of Black, for Python code formatting.
       - id: pyink
 
-  - repo: https://github.com/psf/black
-    rev: 23.3.0 # Always use the same version as PyInk.
-    hooks: # Using black for Jupyter Notebook formatting.
-      - id: black-jupyter
-
   - repo: https://github.com/nbQA-dev/nbQA
     rev: 1.7.0
     hooks:
       - id: nbqa-ruff # Run `ruff` on Jupyter Notebooks.
+
+  - repo: https://github.com/psf/black
+    rev: 23.3.0 # Always use the same version as PyInk.
+    hooks: # Using black for Jupyter Notebook formatting.
+      - id: black-jupyter
 
 #  - repo: local # Clear Jupyter outputs before committing.
 #    hooks:

--- a/Dockerfile
+++ b/Dockerfile
@@ -523,6 +523,7 @@ FROM train-base AS train-interactive-exclude
 
 COPY --link --from=train-builds /opt/conda /opt/conda
 RUN echo /opt/conda/lib >> /etc/ld.so.conf.d/conda.conf && ldconfig
+RUN chsh --shell /bin/zsh
 
 ########################################################################
 FROM train-interactive-${INTERACTIVE_MODE} AS train

--- a/dockerfiles/simple.Dockerfile
+++ b/dockerfiles/simple.Dockerfile
@@ -154,6 +154,7 @@ FROM train-base AS train-interactive-exclude
 # container registries such as Docker Hub. No users or interactive settings.
 COPY --link --from=install-conda /opt/conda /opt/conda
 RUN echo /opt/conda/lib >> /etc/ld.so.conf.d/conda.conf && ldconfig
+RUN chsh --shell /bin/zsh
 
 ########################################################################
 FROM train-base AS train-interactive-include

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,6 +30,7 @@ testpaths = [
 line-length = 100
 target-version = 'py38'
 select = [
+#    "A", # flake8-builtins
     "B", # flake8-bugbear
     "BLE", # flake8-blind-except
     "C4", # flake8-comprehensions
@@ -38,10 +39,16 @@ select = [
     "E", # pycodestyle errors
     "F", # pyflakes
     "I", # isort
+    "ICN", # flake8-import-conventions
+    "ISC", # flake8-implicit-str-concat
 #    "N", # PEP8-Naming
     "NPY", # NumPy-specific rules
-    "PLE", # Error
-    "PLW", # Warning
+    "PLC", # Pylint Convention
+    "PLE", # Pylint Error
+    "PLW", # Pylint Warning
+    "PT", # flake8-pytest-style
+    "SIM", # flake8-simplify
+    "T10", # flake8-debugger
 #    "UP", # PyUpgrade
     "W", # pycodestyle warnings
     "YTT",  # flake8-2020

--- a/tests/test_run.py
+++ b/tests/test_run.py
@@ -40,12 +40,12 @@ logger.setLevel(logging.INFO)
 
 
 @pytest.fixture(scope="session", autouse=True)
-def enable_cudnn_benchmarking():
+def _enable_cudnn_benchmarking():
     torch.backends.cudnn.benchmark = True
 
 
 @pytest.fixture(scope="session", autouse=True)
-def allow_tf32():
+def _allow_tf32():
     torch.backends.cuda.matmul.allow_tf32 = True
     torch.backends.cudnn.allow_tf32 = True
 
@@ -88,7 +88,7 @@ def num_steps(pytestconfig):
     return pytestconfig.getoption("num_steps")
 
 
-@pytest.mark.parametrize(["name", "network_func", "input_shapes"], _configs)
+@pytest.mark.parametrize(("name", "network_func", "input_shapes"), _configs)
 def test_inference_run(
     name: str,
     network_func: Callable[[], nn.Module],
@@ -150,7 +150,7 @@ def _infer(network: nn.Module, inputs: Sequence[Tensor], num_steps: int) -> floa
 
 
 @pytest.fixture(scope="session", autouse=True)
-def get_cuda_info(device):  # Using as a fixture to get device info.
+def _get_cuda_info(device):  # Using as a fixture to get device info.
     logger.info(f"Python Version: {platform.python_version()}")
     logger.info(f"PyTorch Version: {torch.__version__}")
     if not torch.cuda.is_available():


### PR DESCRIPTION
Fix pre-commits to execute `ruff` first for Jupyter notebooks.
Add many new `ruff` rules which seem reasonable.
Change the login shell to `zsh` for all images in all configurations.
Update PyTest test function names to be consistent with the new style guide specified via the new `ruff` rules.