### PR TITLE
Fix ngc zsh formatting issue.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -523,6 +523,8 @@ FROM train-base AS train-interactive-exclude
 # possible, with the same `apt`, `conda`, and `pip` packages installed.
 # Most users may safely ignore this stage except when publishing an image
 # to a container repository for reproducibility.
+# Note that `zsh` configs are available but these images do not require `zsh`.
+# This allows users who download these images to use them interactively.
 
 COPY --link --from=train-builds /opt/conda /opt/conda
 RUN echo /opt/conda/lib >> /etc/ld.so.conf.d/conda.conf && ldconfig

--- a/dockerfiles/hub.Dockerfile
+++ b/dockerfiles/hub.Dockerfile
@@ -123,6 +123,7 @@ FROM train-base AS train-interactive-exclude
 # are unnecessary and having the user set to `root` is most convenient.
 # Most users may safely ignore this stage except when publishing an image
 # to a container repository for reproducibility.
+# Note that `zsh` configs are available but these images do not require `zsh`.
 
 ########################################################################
 FROM train-interactive-${INTERACTIVE_MODE} AS train

--- a/dockerfiles/ngc.Dockerfile
+++ b/dockerfiles/ngc.Dockerfile
@@ -34,6 +34,9 @@ ARG PYTHONUNBUFFERED=1
 # The base NGC image sets `SHELL=bash`. Docker cannot unset an `ENV` variable,
 # ergo, `SHELL=''` is used for best compatibility with the other services.
 ENV SHELL=''
+# Change permissions for the `/root` directory (but not recursively) to allow
+# other users to share configurations. Only the NGC image needs explicit chmod.
+RUN chmod 755 /root
 
 # Install `apt` requirements.
 # `tzdata` requires noninteractive mode.
@@ -118,6 +121,7 @@ FROM train-base AS train-interactive-exclude
 # are unnecessary and having the user set to `root` is most convenient.
 # Most users may safely ignore this stage except when publishing an image
 # to a container repository for reproducibility.
+# Note that `zsh` configs are available but these images do not require `zsh`.
 
 ########################################################################
 FROM train-interactive-${INTERACTIVE_MODE} AS train

--- a/dockerfiles/simple.Dockerfile
+++ b/dockerfiles/simple.Dockerfile
@@ -170,6 +170,7 @@ RUN echo "source ${ZSHS_PATH}/zsh-syntax-highlighting.zsh" >> ${ZDOTDIR}/.zshrc
 FROM train-base AS train-interactive-exclude
 # Stage used to create images for Kubernetes clusters or for uploading to
 # container registries such as Docker Hub. No users or interactive settings.
+# Note that `zsh` configs are available but these images do not require `zsh`.
 COPY --link --from=install-conda /opt/conda /opt/conda
 RUN echo /opt/conda/lib >> /etc/ld.so.conf.d/conda.conf && ldconfig
 


### PR DESCRIPTION
Fix the issue where `.zshrc` could not be read in the `ngc` image. 
Also add comments on why this was done, to allow downloaded images to be used interactively.