### PR TITLE
Minor build argument fix and addition of documentation on variable priority order.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -211,14 +211,18 @@ COPY --link --from=clone-torch /opt/pytorch /opt/pytorch
 
 # Read `setup.py` and `CMakeLists.txt` to find build flags.
 # Different flags are available for different versions of PyTorch.
-# Variables without default values here recieve defaults from the top of the Dockerfile.
-# Disabling NNPack and QNNPack by default as they are legacy and most users do not need them.
+# Variables without defaults here recieve defaults from the top of the file.
+# Variables must be defined both in the Dockerfile and `docker-compose.yaml`
+# to be configurable via `.env`. Check `docker-compose.yaml` if a variable
+# cannot be specified via `.env`. Note that variable definitions in
+# `docker-compose.yaml` override default values specified in the Dockerfile.
+# Default values in `docker-compose.yaml` therefore have higher priority than
+# default values specified for variables in the Dockerfile.
 ARG USE_CUDA
 ARG USE_CUDNN=${USE_CUDA}
-ARG USE_NNPACK=0
-ARG USE_QNNPACK=0
-ARG BUILD_TEST=1
-ARG USE_EXPERIMENTAL_CUDNN_V8_API=1
+ARG USE_NNPACK
+ARG USE_QNNPACK
+ARG BUILD_TEST
 ARG USE_PRECOMPILED_HEADERS
 ARG TORCH_CUDA_ARCH_LIST
 ARG CMAKE_PREFIX_PATH=/opt/conda
@@ -236,7 +240,7 @@ RUN --mount=type=cache,target=/opt/ccache \
 #    python setup.py build --cmake-only && \
 #    ccmake build  # or cmake-gui build
 
-# See the SetupTools documentation for more setup.py options.
+# Visit the Setuptools documentation for more `setup.py` options.
 # https://setuptools.pypa.io/en/latest
 
 # C++ developers using Libtoch can find the library in `torch/lib/tmp_install/lib/libtorch.so`.

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -108,10 +108,9 @@ services:
       dockerfile: Dockerfile
       args: # Equivalent to `--build-arg`.
         BUILD_MODE: ${BUILD_MODE:-exclude}
-        BUILD_TEST: 1 # Enable tests to have identical configurations with deployment.
-        USE_NNPACK: 0
-        USE_QNNPACK: 0
-        USE_EXPERIMENTAL_CUDNN_V8_API: 1
+        BUILD_TEST: 1
+        USE_NNPACK: 0 # Disabling NNPack and QNNPack by default as they are
+        USE_QNNPACK: 0 # legacy libraries and most users do not need them.
         LINUX_DISTRO: ${LINUX_DISTRO:-ubuntu}
         DISTRO_VERSION: ${DISTRO_VERSION:-22.04}
         CUDA_VERSION: ${CUDA_VERSION:-11.8.0}
@@ -125,7 +124,7 @@ services:
         # The `CONDA_MANAGER` may be either `mamba` (the default) or `conda`.
         # However, `mamba` may be unable to resolve conflicts that `conda` can.
         # In such cases, set `CONDA_MANAGER=conda` for conda-based installation.
-        # Installing `mamba` via Mambaforge is strongly recommended.
+        # Installing `mamba` via mamba-forge is strongly recommended.
         CONDA_URL: ${CONDA_URL:-https://github.com/conda-forge/miniforge/releases/latest/download/Mambaforge-Linux-x86_64.sh}
         CONDA_MANAGER: ${CONDA_MANAGER:-mamba}
         # Fails if `BUILD_MODE=include` but `CCA` is not set explicitly.


### PR DESCRIPTION
Remove cuDNNv8 experimental flag as it is enabled on PyTorch 2.x anyway. Also, I do not like anything labeled "experimental" on the main image. Users can add that themselves.

Also remove confusing defaults from the Dockerfile and add many comments on how arguments are passed on from the `.env` file to the `docker-compose.yaml` file and finally the `Dockerfile`.