### PR TITLE
Fix compilation issues in PyTorch build.

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -29,7 +29,7 @@ repos:
 
   # Ruff should be executed before other formatters.
   - repo: https://github.com/charliermarsh/ruff-pre-commit
-    rev: v0.0.264
+    rev: v0.0.265
     hooks:
       - id: ruff
         args: [--exit-non-zero-on-fix]

--- a/Dockerfile
+++ b/Dockerfile
@@ -182,12 +182,8 @@ ENV PATH=/opt/conda/bin/ccache:$PATH
 # Enable `ccache` with unlimited memory size for faster builds.
 RUN ccache --set-config=cache_dir=/opt/ccache && ccache --max-size 0
 
-# Use LLD as the default linker for faster linking.
-RUN ln -sf /opt/conda/bin/ld.lld /usr/bin/ld
-
-# Use `ldconfig` to update link directories and include `conda` in dynamic linking.
-# Setting `LD_LIBRARY_PATH` directly is bad practice.
-RUN echo /opt/conda/lib >> /etc/ld.so.conf.d/conda.conf && ldconfig
+# Use LLD as the default linker for faster linking. Also update dynamic links.
+RUN ln -sf /opt/conda/bin/ld.lld /usr/bin/ld && ldconfig
 
 ########################################################################
 FROM ${GIT_IMAGE} AS clone-torch
@@ -502,8 +498,6 @@ RUN groupadd -f -g ${GID} ${GRP} && \
 
 # Get conda with the directory ownership given to the user.
 COPY --link --from=train-builds --chown=${UID}:${GID} /opt/conda /opt/conda
-# The `ldconfig` command is necessary for PyTorch to find MKL and other libraries.
-RUN echo /opt/conda/lib >> /etc/ld.so.conf.d/conda.conf && ldconfig
 
 # Add custom `zsh` aliases and settings.
 # Add `ll` alias for convenience. The Mac version of `ll` is used
@@ -529,7 +523,6 @@ FROM train-base AS train-interactive-exclude
 # This allows users who download these images to use them interactively.
 
 COPY --link --from=train-builds /opt/conda /opt/conda
-RUN echo /opt/conda/lib >> /etc/ld.so.conf.d/conda.conf && ldconfig
 
 ########################################################################
 FROM train-interactive-${INTERACTIVE_MODE} AS train
@@ -558,6 +551,9 @@ ENV MALLOC_CONF="background_thread:true,metadata_thp:auto,dirty_decay_ms:30000,m
 # Only the `/root` directory iteself needs permission modification.
 # Subdirectory permissions are intentionally left unmodified.
 RUN chmod 711 /root
+
+# Updae dynamic link cache.
+RUN ldconfig
 
 # `PROJECT_ROOT` is where the project code will reside.
 # The conda root path must be placed at the end of the

--- a/Makefile
+++ b/Makefile
@@ -54,7 +54,8 @@ PROJECT_ROOT=${PROJECT_ROOT}\n$\
 # The `.env` file must be checked via shell as is cannot be a Makefile target.
 # Doing so would make it impossible to reference `.env` in the `-include` command.
 env:  # Creates the `.env` file if it does not exist.
-	@test -f ${ENV_FILE} || printf ${ENV_TEXT} >> ${ENV_FILE}
+	@if [ -f ${ENV_FILE} ]; then echo "\`${ENV_FILE}\` already exists!"; \
+  	else printf ${ENV_TEXT} >> ${ENV_FILE}; fi
 
 check:  # Checks if the `.env` file exists.
 	@if [ ! -f "${ENV_FILE}" ]; then \
@@ -62,7 +63,6 @@ check:  # Checks if the `.env` file exists.
 		printf "Run \`make env\` to create \`${ENV_FILE}\`.\n" && \
 		exit 1; \
 	fi
-
 
 # Creates VSCode server directory to prevent Docker Compose
 # from creating the directory with `root` ownership.

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -113,6 +113,7 @@ services:
         USE_QNNPACK: 0 # legacy libraries and most users do not need them.
         BUILD_CAFFE2: 0 # Most users do not need Caffe2.
         BUILD_CAFFE2_OPS: 0
+        USE_PRECOMPILED_HEADERS: 1
         LINUX_DISTRO: ${LINUX_DISTRO:-ubuntu}
         DISTRO_VERSION: ${DISTRO_VERSION:-22.04}
         CUDA_VERSION: ${CUDA_VERSION:-11.8.0}

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -108,9 +108,11 @@ services:
       dockerfile: Dockerfile
       args: # Equivalent to `--build-arg`.
         BUILD_MODE: ${BUILD_MODE:-exclude}
-        BUILD_TEST: 1
+        BUILD_TEST: 0
         USE_NNPACK: 0 # Disabling NNPack and QNNPack by default as they are
         USE_QNNPACK: 0 # legacy libraries and most users do not need them.
+        BUILD_CAFFE2: 0 # Most users do not need Caffe2.
+        BUILD_CAFFE2_OPS: 0
         LINUX_DISTRO: ${LINUX_DISTRO:-ubuntu}
         DISTRO_VERSION: ${DISTRO_VERSION:-22.04}
         CUDA_VERSION: ${CUDA_VERSION:-11.8.0}
@@ -130,12 +132,12 @@ services:
         # Fails if `BUILD_MODE=include` but `CCA` is not set explicitly.
         TORCH_CUDA_ARCH_LIST: ${CCA} # Ignore the missing CCA warning otherwise.
         # Variables for building PyTorch. Must be valid git tags or commits.
-        PYTORCH_VERSION_TAG: ${PYTORCH_VERSION_TAG:-v2.0.0}
-        TORCHVISION_VERSION_TAG: ${TORCHVISION_VERSION_TAG:-v0.15.1}
+        PYTORCH_VERSION_TAG: ${PYTORCH_VERSION_TAG:-v2.0.1}
+        TORCHVISION_VERSION_TAG: ${TORCHVISION_VERSION_TAG:-v0.15.2}
         # Variables for downloading PyTorch instead of building.
         PYTORCH_INDEX_URL: ${PYTORCH_INDEX_URL:-https://download.pytorch.org/whl/cu118}
-        PYTORCH_VERSION: ${PYTORCH_VERSION:-2.0.0}
-        TORCHVISION_VERSION: ${TORCHVISION_VERSION:-0.15.1}
+        PYTORCH_VERSION: ${PYTORCH_VERSION:-2.0.1}
+        TORCHVISION_VERSION: ${TORCHVISION_VERSION:-0.15.2}
         # URLs for faster `apt` and `pip` installs. Comment out to use the defaults.
         # Use URLs optimized for location and security requirements.
         # DEB_OLD: ${DEB_OLD:-http://archive.ubuntu.com}
@@ -168,7 +170,7 @@ services:
     build:
       dockerfile: dockerfiles/hub.Dockerfile
       args:
-        PYTORCH_VERSION: ${PYTORCH_VERSION:-2.0.0}
+        PYTORCH_VERSION: ${PYTORCH_VERSION:-2.0.1}
         # Note that `CUDA_SHORT_VERSION` excludes the patch version numbers.
         CUDA_SHORT_VERSION: ${CUDA_SHORT_VERSION:-11.7}
         CUDNN_VERSION: ${CUDNN_VERSION:-8}

--- a/dockerfiles/hub.Dockerfile
+++ b/dockerfiles/hub.Dockerfile
@@ -56,7 +56,7 @@ RUN --mount=type=cache,target=${PIP_CACHE_DIR},sharing=locked \
     --mount=type=bind,from=stash,source=/tmp/req,target=/tmp/req \
     conda install --freeze-installed -n base -c conda-forge \
         --file /tmp/req/requirements.txt && \
-    ldconfig
+    ldconfig  # Run `ldconfig` to update dynamic linking paths.
 
 # Enable Intel MKL optimizations on AMD CPUs.
 # https://danieldk.eu/Posts/2020-08-31-MKL-Zen.html

--- a/dockerfiles/hub.Dockerfile
+++ b/dockerfiles/hub.Dockerfile
@@ -56,7 +56,7 @@ RUN --mount=type=cache,target=${PIP_CACHE_DIR},sharing=locked \
     --mount=type=bind,from=stash,source=/tmp/req,target=/tmp/req \
     conda install --freeze-installed -n base -c conda-forge \
         --file /tmp/req/requirements.txt && \
-    echo /opt/conda/lib >> /etc/ld.so.conf.d/conda.conf && ldconfig
+    ldconfig
 
 # Enable Intel MKL optimizations on AMD CPUs.
 # https://danieldk.eu/Posts/2020-08-31-MKL-Zen.html

--- a/dockerfiles/simple.Dockerfile
+++ b/dockerfiles/simple.Dockerfile
@@ -219,7 +219,7 @@ ENV MALLOC_CONF="background_thread:true,metadata_thp:auto,dirty_decay_ms:30000,m
 # Change `/root` directory permissions to allow configuration sharing.
 RUN chmod 711 /root
 
-# Update dynamic linking locations
+# Update dynamic linking locations.
 RUN ldconfig
 
 ARG PROJECT_ROOT=/opt/project

--- a/dockerfiles/simple.Dockerfile
+++ b/dockerfiles/simple.Dockerfile
@@ -172,7 +172,6 @@ FROM train-base AS train-interactive-exclude
 # container registries such as Docker Hub. No users or interactive settings.
 # Note that `zsh` configs are available but these images do not require `zsh`.
 COPY --link --from=install-conda /opt/conda /opt/conda
-RUN echo /opt/conda/lib >> /etc/ld.so.conf.d/conda.conf && ldconfig
 
 ########################################################################
 FROM train-base AS train-interactive-include
@@ -192,7 +191,6 @@ RUN groupadd -f -g ${GID} ${GRP} && \
 
 # Get conda with the directory ownership given to the user.
 COPY --link --from=install-conda --chown=${UID}:${GID} /opt/conda /opt/conda
-RUN echo /opt/conda/lib >> /etc/ld.so.conf.d/conda.conf && ldconfig
 
 # Add custom aliases and settings.
 RUN {   echo "alias ll='ls -lh'"; \
@@ -220,6 +218,9 @@ ENV MALLOC_CONF="background_thread:true,metadata_thp:auto,dirty_decay_ms:30000,m
 
 # Change `/root` directory permissions to allow configuration sharing.
 RUN chmod 711 /root
+
+# Update dynamic linking locations
+RUN ldconfig
 
 ARG PROJECT_ROOT=/opt/project
 ENV PATH=${PROJECT_ROOT}:/opt/conda/bin:${PATH}


### PR DESCRIPTION
Closes #132 
Closes #133 

Stop including `/opt/conda/lib` in the dynamic link search path. However, `ldconfig` is still called after all `apt`, `pip`, and `conda` packages are installed.

Update the `ccache` settings to use the recommendations provided in the contributing guide. https://github.com/pytorch/pytorch/blob/main/CONTRIBUTING.md#use-ccache

Also reinstate the `nvcc` header fixing code, at least for the PyTorch-related compilation stages.