### PR TITLE
Add compilation to the `simple` service.

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,28 +31,38 @@ line-length = 100
 target-version = 'py38'
 select = [
 #    "A", # flake8-builtins
+#    "ARG", # flake8-unused-arguments
     "B", # flake8-bugbear
     "BLE", # flake8-blind-except
     "C4", # flake8-comprehensions
     "C90", # mccabe
     "D", # pydocstyle
     "E", # pycodestyle errors
+#    "EM", # flake8-errmsg
     "F", # pyflakes
+    "G010", # logging-warn
     "I", # isort
     "ICN", # flake8-import-conventions
     "ISC", # flake8-implicit-str-concat
 #    "N", # PEP8-Naming
     "NPY", # NumPy-specific rules
+    "PD", # pandas-vet
+    "PIE", # flake8-pie
     "PLC", # Pylint Convention
     "PLE", # Pylint Error
+#    "PLR", # Pylint Refactor
     "PLW", # Pylint Warning
     "PT", # flake8-pytest-style
+    "RSE", # flake8-raise
+    "RUF",  # Ruff-specific rules
     "SIM", # flake8-simplify
     "T10", # flake8-debugger
+    "TCH", # flake8-type-checking
+    "TID", # flake8-tidy-imports
+    "TRY", # tryceratops
 #    "UP", # PyUpgrade
     "W", # pycodestyle warnings
     "YTT",  # flake8-2020
-    "RUF",  # Ruff-specific rules
 ]
 ignore = [
   "C408", # unnecessary-collection-call

--- a/tests/test_run.py
+++ b/tests/test_run.py
@@ -100,7 +100,8 @@ def test_inference_run(
     enable_scripting: bool = False,
 ):
     if enable_amp and enable_scripting:
-        raise RuntimeError("AMP is incompatible with TorchScript.")
+        msg = "AMP is incompatible with TorchScript."
+        raise RuntimeError(msg)
     logger.info(f"Model: {name}.")
     logger.info(f"Input shapes: {input_shapes}.")
     logger.info(f"Automatic Mixed Precision Enabled: {enable_amp}.")


### PR DESCRIPTION
Add the GCC compiler from the official Docker image for GCC. Unfortunately, Clang/LLVM does not have an official Docker image.
Update the `ruff` rules list to have many more rules.