### PR TITLE
Disable KMP_AFFINITY as it causes all threads to run on a single core.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -541,7 +541,7 @@ FROM train-adduser-${ADD_USER} AS train
 # Intel OpenMP thread blocking time in ms.
 ENV KMP_BLOCKTIME=0
 # Configure CPU thread affinity.
-ENV KMP_AFFINITY="granularity=fine,compact,1,0"
+# ENV KMP_AFFINITY="granularity=fine,compact,1,0"
 ENV LD_PRELOAD=/opt/conda/lib/libiomp5.so:${LD_PRELOAD}
 
 # Enable Intel MKL optimizations on AMD CPUs.

--- a/dockerfiles/hub.Dockerfile
+++ b/dockerfiles/hub.Dockerfile
@@ -67,7 +67,7 @@ RUN echo 'int mkl_serv_intel_cpu_true() {return 1;}' > /opt/conda/fakeintel.c &&
 ENV LD_PRELOAD=/opt/conda/libfakeintel.so:${LD_PRELOAD}
 
 ENV KMP_BLOCKTIME=0
-ENV KMP_AFFINITY="granularity=fine,compact,1,0"
+# ENV KMP_AFFINITY="granularity=fine,compact,1,0"
 ENV LD_PRELOAD=/opt/conda/lib/libiomp5.so:${LD_PRELOAD}
 
 # Jemalloc configurations.

--- a/dockerfiles/ngc.Dockerfile
+++ b/dockerfiles/ngc.Dockerfile
@@ -141,7 +141,7 @@ COPY --link --from=install-conda /opt/conda /opt/conda
 FROM train-adduser-${ADD_USER} AS train
 
 ENV KMP_BLOCKTIME=0
-ENV KMP_AFFINITY="granularity=fine,compact,1,0"
+# ENV KMP_AFFINITY="granularity=fine,compact,1,0"
 # Use `/opt/conda/lib/libiomp5.so` for older NGC images using `conda`.
 # Using the older system MKL to prevent version clashes with NGC packages.
 ENV LD_PRELOAD=/usr/local/lib/libiomp5.so:${LD_PRELOAD}

--- a/dockerfiles/simple.Dockerfile
+++ b/dockerfiles/simple.Dockerfile
@@ -220,7 +220,7 @@ FROM train-adduser-${ADD_USER} AS train
 # Use Intel OpenMP with optimizations. See the documentation for details.
 # https://intel.github.io/intel-extension-for-pytorch/cpu/latest/tutorials/performance_tuning/tuning_guide.html
 ENV KMP_BLOCKTIME=0
-ENV KMP_AFFINITY="granularity=fine,compact,1,0"
+# ENV KMP_AFFINITY="granularity=fine,compact,1,0"
 ENV LD_PRELOAD=/opt/conda/lib/libiomp5.so:${LD_PRELOAD}
 
 # Enable Intel MKL optimizations on AMD CPUs.


### PR DESCRIPTION
Closes #148 