### PR TITLE
Clean up `/tmp`.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -559,6 +559,8 @@ RUN {   echo "fpath+=${PURE_PATH}"; \
     } >> ${ZDOTDIR}/.zprofile && \
     # Change `ZDOTDIR` directory permissions to allow configuration sharing.
     chmod 755 ${ZDOTDIR} && \
+    # Clear out `/tmp` and restore its default permissions.
+    rm -rf /tmp && mkdir /tmp && chmod 1777 /tmp && \
     ldconfig  # Update dynamic link cache.
 
 ENV PATH=/opt/conda/bin:${PATH}

--- a/dockerfiles/ngc.Dockerfile
+++ b/dockerfiles/ngc.Dockerfile
@@ -194,6 +194,8 @@ RUN ln -s /opt/conda/lib/$(python -V | awk -F '[ \.]' '{print "python" $2 "." $3
     } >> ${ZDOTDIR}/.zprofile && \
     # Change `ZDOTDIR` directory permissions to allow configuration sharing.
     chmod 755 ${ZDOTDIR} && \
+    # Clear out `/tmp` and restore its default permissions.
+    rm -rf /tmp && mkdir /tmp && chmod 1777 /tmp && \
     ldconfig  # Update dynamic link cache.
 
 # No alternative to adding the `/opt/conda/bin` directory to `PATH`.

--- a/dockerfiles/simple.Dockerfile
+++ b/dockerfiles/simple.Dockerfile
@@ -259,6 +259,8 @@ RUN {   echo "fpath+=${PURE_PATH}"; \
     } >> ${ZDOTDIR}/.zprofile && \
     # Change `ZDOTDIR` directory permissions to allow configuration sharing.
     chmod 755 ${ZDOTDIR} && \
+    # Clear out `/tmp` and restore its default permissions.
+    rm -rf /tmp && mkdir /tmp && chmod 1777 /tmp && \
     ldconfig  # Update dynamic link cache.
 
 ENV PATH=/opt/conda/bin:${PATH}


### PR DESCRIPTION
The `/tmp` directory has often caused permission issues. Therefore, it is being cleared out and restored to its default state before the image is used for anything else. Unfortunately, this will not save memory as deleting directories in Docker does not reduce the image size.